### PR TITLE
Adding QuoteBox styles and state.

### DIFF
--- a/src/components/QuoteBox.js
+++ b/src/components/QuoteBox.js
@@ -1,13 +1,22 @@
 import React from 'react';
 import '../styles/base.css';
 
-function QuoteBox() {
+function QuoteBox(props) {
   return (
-    <div className='text-center quoteBox'>
-      <h1>Hello World!</h1>
-      <p>This is React</p>
+    <div className='container-fluid quoteBox'>
+      <blockquote className='blockquote'>
+      <p className='mb-0'> {props.quote} </p>
+      <footer className='blockquote-footer'> {props.author} </footer>
+      </blockquote>
+      <button className='btn btn-default pull-left' type='submit'>Tweet</button>
+      <button className='btn btn-default pull-right' type='submit'>New Quote</button>
     </div>
   )
+}
+
+QuoteBox.propTypes = {
+  quote: React.PropTypes.string.isRequired,
+  author: React.PropTypes.string.isRequired
 }
 
 export default QuoteBox;

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -1,10 +1,21 @@
 import React, { Component } from 'react';
-import Hello from '../components/QuoteBox';
+import QuoteBox from '../components/QuoteBox';
 
 class AppContainer extends Component{
+  constructor() {
+    super();
+    this.state = {
+      quote: 'Men are disturbed not by things, but by the view which they take of them.',
+      author: 'Epictetus'
+    }
+  }
+
   render() {
     return (
-      <Hello />
+      <QuoteBox
+        quote={this.state.quote}
+        author={this.state.author}
+      />
     )
   }
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,6 +1,11 @@
+body {
+  background-color: aliceblue;
+}
 .quoteBox {
+  background-color: white;
   border-radius: 3px;
-  background: white;
+  position: relative;
+  margin: 8% auto auto auto;
+  width: 450px;
   padding: 40px 50px;
-  margin: 10%;
 }


### PR DESCRIPTION
# Description

Adding CSS styling for `QuoteBox` and `state` stuff for components.

## Tech changes

- Modified CSS styles:
  - Added `aliceblue` as the `background-color` for the `body`.
  - Properly centered `QuoteBox` without Bootstrap grids.
- Created default `state` using the `constructor()` lifecycle method.
- `QuoteBox` now receives the quote and author as `props` (as opposed to being hard-coded).
- `PropTypes` validation in the `QuoteBox` component.